### PR TITLE
Remove "observer" status from several entries

### DIFF
--- a/meetings/2024-10-11.md
+++ b/meetings/2024-10-11.md
@@ -21,9 +21,9 @@
 ## Attendees
 
 - Philippe Ombredanne, creator of PURL, Lead maintainer of AboutCode, TC54-TG2 convener
-- Steve Springett, ServiceNow, OWASP Board of Directors, TC54 chair, observer
-- Adam Herzog, AboutCode, observer
-- John Horan, AboutCode, observer
+- Steve Springett, ServiceNow, OWASP Board of Directors, TC54 chair
+- Adam Herzog, AboutCode
+- John Horan, AboutCode
 
 ## Notes:
 


### PR DESCRIPTION
As the title suggests I removed the "observer" status from several entries in the 2024-10-11 notes.